### PR TITLE
force tagging

### DIFF
--- a/src/main/java/com/cloudbees/dockerpublish/DockerBuilder.java
+++ b/src/main/java/com/cloudbees/dockerpublish/DockerBuilder.java
@@ -95,7 +95,7 @@ public class DockerBuilder extends Builder {
         if (getRepoTag() == null || repoTag.trim().isEmpty()) {
             return "echo 'Nothing to build or tag'";
         } else {
-            return "docker tag " + getRepoName() + " " + getNameAndTag();
+            return "docker tag -f " + getRepoName() + " " + getNameAndTag();
         }
     }
 


### PR DESCRIPTION
Since Docker 1.4, if the build image already exists, the **-f** is required when tagging. Otherwise, the build step will fail.