### PR TITLE
Proposed fix for JENKINS-25689

### DIFF
--- a/src/main/java/com/cloudbees/dockerpublish/DockerBuilder.java
+++ b/src/main/java/com/cloudbees/dockerpublish/DockerBuilder.java
@@ -30,7 +30,7 @@ public class DockerBuilder extends Builder {
     private final String dockerfilePath;
     private final boolean skipBuild;
     private final boolean skipDecorate;
-    private final boolean tagLatest;
+    private final boolean skipTagLatest;
     private String repoTag;
     private boolean skipPush = true;
 
@@ -40,7 +40,7 @@ public class DockerBuilder extends Builder {
     * for the actual HTML fragment for the configuration screen.
     */
     @DataBoundConstructor
-    public DockerBuilder(String repoName, String repoTag, boolean skipPush, boolean noCache, boolean skipBuild, boolean skipDecorate, boolean tagLatest, String dockerfilePath) {
+    public DockerBuilder(String repoName, String repoTag, boolean skipPush, boolean noCache, boolean skipBuild, boolean skipDecorate, boolean skipTagLatest, String dockerfilePath) {
         this.repoName = repoName;
         this.repoTag = repoTag;
         this.skipPush = skipPush;
@@ -48,7 +48,7 @@ public class DockerBuilder extends Builder {
         this.dockerfilePath = dockerfilePath;
         this.skipBuild = skipBuild;
         this.skipDecorate = skipDecorate;
-        this.tagLatest = tagLatest;
+        this.skipTagLatest = skipTagLatest;
     }
 
     public String getRepoName() {return repoName; }
@@ -57,7 +57,7 @@ public class DockerBuilder extends Builder {
     public boolean isSkipBuild() { return skipBuild;}
     public boolean isSkipDecorate() { return skipDecorate;}
     public boolean isNoCache() { return noCache;}
-    public boolean isTagLatest() { return tagLatest;}
+    public boolean isSkipTagLatest() { return skipTagLatest;}
     public String getDockerfilePath() { return dockerfilePath; }
 
 
@@ -151,7 +151,7 @@ public class DockerBuilder extends Builder {
         if (!isSkipPush()) {
             String nameAndTag = TokenMacro.expandAll(build, listener, getNameAndTag());
             boolean result = executeCmd(build, launcher, listener, dockerPushCommand(build, listener, nameAndTag));
-            if (result && isTagLatest()) {
+            if (result && isSkipTagLatest()) {
                 // rebuild the image with the latest tag
                 String latest = getRepoName() + ":latest";
                 result = executeCmd(build, launcher, listener, buildAndTag(build, listener, latest));

--- a/src/main/java/com/cloudbees/dockerpublish/DockerBuilder.java
+++ b/src/main/java/com/cloudbees/dockerpublish/DockerBuilder.java
@@ -30,6 +30,7 @@ public class DockerBuilder extends Builder {
     private final String dockerfilePath;
     private final boolean skipBuild;
     private final boolean skipDecorate;
+    private final boolean tagLatest;
     private String repoTag;
     private boolean skipPush = true;
 
@@ -39,7 +40,7 @@ public class DockerBuilder extends Builder {
     * for the actual HTML fragment for the configuration screen.
     */
     @DataBoundConstructor
-    public DockerBuilder(String repoName, String repoTag, boolean skipPush, boolean noCache, boolean skipBuild, boolean skipDecorate, String dockerfilePath) {
+    public DockerBuilder(String repoName, String repoTag, boolean skipPush, boolean noCache, boolean skipBuild, boolean skipDecorate, boolean tagLatest, String dockerfilePath) {
         this.repoName = repoName;
         this.repoTag = repoTag;
         this.skipPush = skipPush;
@@ -47,6 +48,7 @@ public class DockerBuilder extends Builder {
         this.dockerfilePath = dockerfilePath;
         this.skipBuild = skipBuild;
         this.skipDecorate = skipDecorate;
+        this.tagLatest = tagLatest;
     }
 
     public String getRepoName() {return repoName; }
@@ -55,6 +57,7 @@ public class DockerBuilder extends Builder {
     public boolean isSkipBuild() { return skipBuild;}
     public boolean isSkipDecorate() { return skipDecorate;}
     public boolean isNoCache() { return noCache;}
+    public boolean isTagLatest() { return tagLatest;}
     public String getDockerfilePath() { return dockerfilePath; }
 
 
@@ -66,7 +69,7 @@ public class DockerBuilder extends Builder {
      * In docker - you push the whole repo to trigger the sync.
      */
     private String getNameAndTag() {
-        if (getRepoTag() == null || repoTag.trim().isEmpty()) {
+        if (getRepoTag() == null || getRepoTag().trim().isEmpty()) {
             return repoName;
         } else {
             return repoName + ":" + repoTag;
@@ -92,7 +95,7 @@ public class DockerBuilder extends Builder {
     }
 
     private String maybeTagOnly(AbstractBuild build, BuildListener listener) {
-        if (getRepoTag() == null || repoTag.trim().isEmpty()) {
+        if (getRepoTag() == null || getRepoTag().trim().isEmpty()) {
             return "echo 'Nothing to build or tag'";
         } else {
             return "docker tag " + getRepoName() + " " + getNameAndTag();
@@ -108,8 +111,8 @@ public class DockerBuilder extends Builder {
         return "docker build -t " + buildTag + ((isNoCache()) ? " --no-cache=true " : "")  + " " + context;
     }
 
-    private String dockerPushCommand(AbstractBuild build, BuildListener listener) throws InterruptedException, MacroEvaluationException, IOException {
-        return "docker push " + TokenMacro.expandAll(build, listener, getNameAndTag());
+    private String dockerPushCommand(AbstractBuild build, BuildListener listener, String tag) throws InterruptedException, MacroEvaluationException, IOException {
+        return "docker push " + tag;
     }
 
 
@@ -146,7 +149,13 @@ public class DockerBuilder extends Builder {
 
     private boolean maybePush(AbstractBuild build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException, MacroEvaluationException {
         if (!isSkipPush()) {
-            return executeCmd(build, launcher, listener, dockerPushCommand(build, listener));
+            String nameAndTag = TokenMacro.expandAll(build, listener, getNameAndTag());
+            boolean result = executeCmd(build, launcher, listener, dockerPushCommand(build, listener, nameAndTag));
+            if (result && isTagLatest()) {
+                String latest = getRepoName() + ":latest";
+                result = executeCmd(build, launcher, listener, dockerPushCommand(build, listener, latest));
+            }
+            return result;
         } else {
             return true;
         }

--- a/src/main/resources/com/cloudbees/dockerpublish/DockerBuilder/config.jelly
+++ b/src/main/resources/com/cloudbees/dockerpublish/DockerBuilder/config.jelly
@@ -32,8 +32,8 @@
         <f:checkbox />
    </f:entry>
 
-   <f:entry title="Tag as latest" field="tagLatest"
-        description="Tag this build as the latest">
+   <f:entry title="Skip tag as latest" field="skipTagLatest"
+        description="Do not tag this build as the latest">
         <f:checkbox />
    </f:entry>
 

--- a/src/main/resources/com/cloudbees/dockerpublish/DockerBuilder/config.jelly
+++ b/src/main/resources/com/cloudbees/dockerpublish/DockerBuilder/config.jelly
@@ -32,6 +32,11 @@
         <f:checkbox />
    </f:entry>
 
+   <f:entry title="Tag as latest" field="tagLatest"
+        description="Tag this build as the latest">
+        <f:checkbox />
+   </f:entry>
+
   <f:entry title="Directory Dockerfile is in" field="dockerfilePath"
     description="The project root is where the Dockerfile is looked for by default - if you need another path, enter it here">
     <f:textbox />


### PR DESCRIPTION
I am working with Jenkins, Docker and a local registry, but I have been encountering problems because when I try to pull images from the local registry I get errors like this:

    Pulling repository  myreg:5000/vpsi/cassandra
    time="2015-01-19T15:38:28Z" level="fatal" 
    msg="Tag latest not found in repository myreg:5000/vpsi/cassandra" 
    Unable to find image 'myreg:5000/vpsi/cassandra:latest' locally

After trying [some alternative solutions](https://github.com/butlermh/docker-build-publish-plugin/commit/30c8c75346209300c9ed5c4d9a6a5fbba8bcc3d8) that [did not work](https://github.com/jenkinsci/docker-build-publish-plugin/pull/6) I concluded the problem is [this change](https://github.com/jenkinsci/docker-build-publish-plugin/pull/3). Before the change it was pushing all the tags of a particular image (including latest), but after it only the explicit tag will be pushed, and not the latest tag hence causing the problem above.

My solution is to also push the latest version, although as requested in JENKINS-25689 I added a checkbox so that this is user configurable. Perhaps that is not necessary, the latest version should always be pushed by default? 

I have tested this version and it does resolve my problem. 