### PR TITLE
[JENKINS-28675] - Create fingerprints when creating new images

### DIFF
--- a/src/main/java/com/cloudbees/dockerpublish/DockerBuilder.java
+++ b/src/main/java/com/cloudbees/dockerpublish/DockerBuilder.java
@@ -7,7 +7,6 @@ import hudson.Launcher;
 import hudson.model.BuildListener;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
-import hudson.model.Computer;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
 import hudson.util.FormValidation;
@@ -15,9 +14,7 @@ import hudson.util.FormValidation;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectStreamException;
-import java.io.PrintStream;
-import java.io.UnsupportedEncodingException;
-import java.nio.charset.Charset;
+import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -213,15 +210,17 @@ public class DockerBuilder extends Builder {
     
     private static class Result {
     	final boolean result;
-    	final String stdout;
+    	final @Nonnull String stdout;
+        final @Nonnull String stderr;
     	
     	private Result() {
-    		this(true, "");
+    		this(true, "", "");
     	}
     	
-    	private Result(boolean result, String stdout) {
+    	private Result(boolean result, @CheckForNull String stdout, @CheckForNull String stderr) {
     		this.result = result;
-    		this.stdout = stdout;
+    		this.stdout = hudson.Util.fixNull(stdout);
+                this.stderr = hudson.Util.fixNull(stderr);
     	}
     }
 
@@ -347,10 +346,36 @@ public class DockerBuilder extends Builder {
         	return lastResult.result;
         }
 
+        /**
+         * Runs Docker command using Docker CLI.
+         * In this default implementation STDOUT and STDERR outputs will be printed to build logs.
+         * Use {@link #executeCmd(java.lang.String, boolean, boolean)} to alter the behavior.
+         * @param cmd Command to be executed
+         * @return Execution result
+         * @throws IOException Execution error
+         * @throws InterruptedException The build has been interrupted
+         */
         private Result executeCmd(String cmd) throws IOException, InterruptedException {
-            ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            TeeOutputStream stdout = new TeeOutputStream(listener.getLogger(), baos);
-            PrintStream stderr = listener.getLogger();
+            return executeCmd(cmd, true, true);
+        }
+        
+        /**
+         * Runs Docker command using Docker CLI.
+         * @param cmd Command to be executed
+         * @param logStdOut If true, propagate STDOUT to the build log
+         * @param logStdErr If true, propagate STDERR to the build log
+         * @return Execution result
+         * @throws IOException Execution error
+         * @throws InterruptedException The build has been interrupted
+         */
+        private @Nonnull Result executeCmd( @Nonnull String cmd, 
+                boolean logStdOut, boolean logStdErr) throws IOException, InterruptedException {
+            ByteArrayOutputStream baosStdOut = new ByteArrayOutputStream();
+            ByteArrayOutputStream baosStdErr = new ByteArrayOutputStream();
+            OutputStream stdout = logStdOut ? 
+                    new TeeOutputStream(listener.getLogger(), baosStdOut) : baosStdOut;
+            OutputStream stderr = logStdErr ? 
+                    new TeeOutputStream(listener.getLogger(), baosStdErr) : baosStdErr;
 
             // get Docker registry credentials
             KeyMaterial registryKey = getRegistry().newKeyMaterialFactory(build).materialize();
@@ -376,22 +401,9 @@ public class DockerBuilder extends Builder {
                         .start().join() == 0;
 
                 // capture the stdout so it can be parsed later on
-                String stdoutStr = null;
-                try {
-                    Computer computer = Computer.currentComputer();
-                    if (computer != null) {
-                        Charset charset = computer.getDefaultCharset();
-                        if (charset != null) {
-                            baos.flush();
-                            stdoutStr = baos.toString(charset.name());
-                        }
-                    }
-                } catch (UnsupportedEncodingException e) {
-                    // we couldn't parse, ignore
-                    logger.log(Level.FINE, "Unable to get stdout from launched command: {}", e);
-                }
-
-                return new Result(result, stdoutStr);
+                final String stdOutStr = DockerCLIHelper.getConsoleOutput(baosStdOut, logger);
+                final String stdErrStr = DockerCLIHelper.getConsoleOutput(baosStdErr, logger);
+                return new Result(result, stdOutStr, stdErrStr);
 
             } finally {
                 registryKey.close();
@@ -419,7 +431,7 @@ public class DockerBuilder extends Builder {
             }
             
             // Retrieve full image ID using another call
-            final Result response = executeCmd("docker inspect " + image);
+            final Result response = executeCmd("docker inspect " + image, false, true);
             if (!response.result) {
                 return; // Bad result, cannot do anything
             }

--- a/src/main/java/com/cloudbees/dockerpublish/DockerCLIHelper.java
+++ b/src/main/java/com/cloudbees/dockerpublish/DockerCLIHelper.java
@@ -1,0 +1,82 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.dockerpublish;
+
+import java.io.IOException;
+import javax.annotation.CheckForNull;
+import net.sf.json.JSONArray;
+import net.sf.json.JSONObject;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+/**
+ * Retrieves the data for {@link DockerBuilder} from docker-java datatypes
+ * @author Oleg Nenashev
+ * @since TODO
+ */
+@Restricted(NoExternalUse.class)
+public class DockerCLIHelper {
+    
+    /**
+     * Retrieves an info about image from command-line outputs.
+     * @param stdout Data output to be parsed
+     * @return ImageId or null
+     * @throws IOException Cannot parse the response
+     * @since TODO
+     */
+    @CheckForNull
+    public static InspectImageResponse parseInspectImageResponse(String stdout) throws IOException {
+        JSONArray array = JSONArray.fromObject(stdout);
+        if (array != null && array.size() > 0) {
+            return new InspectImageResponse(array.getJSONObject(0));
+        } else {
+            return null;
+        }     
+    }
+
+    @Restricted(NoExternalUse.class)
+    public static class InspectImageResponse {
+
+        private final String parent;
+        private final String id;
+
+        public InspectImageResponse(JSONObject inspectImageResponse) throws IOException {
+            this.parent = inspectImageResponse.getString("Parent");
+            this.id = inspectImageResponse.getString("Id");
+        }
+        
+        public InspectImageResponse(String parent, String id) {
+            this.parent = parent;
+            this.id = id;
+        }
+
+        public String getParent() {
+            return parent;
+        }
+
+        public String getId() {
+            return id;
+        }
+    }
+}

--- a/src/main/resources/com/cloudbees/dockerpublish/DockerBuilder/config.jelly
+++ b/src/main/resources/com/cloudbees/dockerpublish/DockerBuilder/config.jelly
@@ -36,6 +36,10 @@
         description="Do not build the image">
         <f:checkbox />
     </f:entry>
+    
+    <f:entry title="${%Create fingerprints}" field="createFingerprint">
+        <f:checkbox default="true"/>
+    </f:entry>
 
     <f:entry title="Skip Decorate" field="skipDecorate"
         description="Do not decorate the build name">

--- a/src/main/resources/com/cloudbees/dockerpublish/DockerBuilder/help-createFingerprint.html
+++ b/src/main/resources/com/cloudbees/dockerpublish/DockerBuilder/help-createFingerprint.html
@@ -1,0 +1,6 @@
+<div>
+  If enabled, the plugin will create fingerprints after the build of each image.
+  These fingerprints are being managed by
+  <a href="https://wiki.jenkins-ci.org/display/JENKINS/Docker+Commons+Plugin">
+    Docker Commons Plugin</a>.   
+</div>

--- a/src/test/java/com/cloudbees/dockerpublish/DockerCLIHelperTest.java
+++ b/src/test/java/com/cloudbees/dockerpublish/DockerCLIHelperTest.java
@@ -1,0 +1,47 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015 Cloudbees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.dockerpublish;
+
+import static org.junit.Assert.*;
+
+import com.google.common.base.Charsets;
+import java.net.URL;
+import org.junit.Test;
+import com.google.common.io.Resources;
+
+/**
+ * Tests for {@link DockerCLIHelper}.
+ * @author Oleg Nenashev
+ */
+public class DockerCLIHelperTest {
+    
+    @Test
+    public void parseDockerInspectImageOutput() throws Exception {
+        URL url = Resources.getResource("dockerInspectImage_response.json");
+        DockerCLIHelper.InspectImageResponse rsp = DockerCLIHelper.parseInspectImageResponse(Resources.toString(url, Charsets.UTF_8));
+        assertNotNull(rsp);
+        assertEquals("5366517d611967756a43c63a3223dbf645c5e9be66d594d86802dee143aad93a", rsp.getId());
+        assertEquals("4300417211ebb75b48b06ed5640d641778f312072d24b37978682345cbb362b1", rsp.getParent());
+    }
+}

--- a/src/test/resources/dockerInspectImage_response.json
+++ b/src/test/resources/dockerInspectImage_response.json
@@ -1,0 +1,95 @@
+[
+  {
+    "Architecture": "amd64",
+    "Author": "Jesse Glick",
+    "Comment": "Workflow Plugin Pipeline Demo",
+    "Config": {
+        "AttachStderr": false,
+        "AttachStdin": false,
+        "AttachStdout": false,
+        "Cmd": [
+            "/bin/sh",
+            "-c",
+            "/var/lib/jenkins/run.sh"
+        ],
+        "CpuShares": 0,
+        "Cpuset": "",
+        "Domainname": "",
+        "Entrypoint": null,
+        "Env": [
+            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+            "MAVEN_VERSION=3.3.1",
+            "JETTY_VERSION=9.2.9.v20150224",
+            "REV=107ea141f5c7581056c6eb53d2ccd222cdf0d58c"
+        ],
+        "ExposedPorts": {
+            "22/tcp": {},
+            "8080/tcp": {},
+            "8081/tcp": {}
+        },
+        "Hostname": "1d42a20b09ac",
+        "Image": "5366517d611967756a43c63a3223dbf645c5e9be66d594d86802dee143aad93a",
+        "Labels": null,
+        "MacAddress": "",
+        "Memory": 0,
+        "MemorySwap": 0,
+        "NetworkDisabled": false,
+        "OnBuild": [],
+        "OpenStdin": false,
+        "PortSpecs": null,
+        "StdinOnce": false,
+        "Tty": false,
+        "User": "",
+        "Volumes": null,
+        "WorkingDir": "/var/lib/jenkins/workflow-plugin-pipeline-demo"
+    },
+    "Container": "3e5af3835a00a99092dc0e877e37f82bfee5a7d73ad63c93ecdba94d6e594665",
+    "ContainerConfig": {
+        "AttachStderr": false,
+        "AttachStdin": false,
+        "AttachStdout": false,
+        "Cmd": [
+            "/bin/sh",
+            "-c",
+            "#(nop) EXPOSE 22/tcp 8080/tcp 8081/tcp"
+        ],
+        "CpuShares": 0,
+        "Cpuset": "",
+        "Domainname": "",
+        "Entrypoint": null,
+        "Env": [
+            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+            "MAVEN_VERSION=3.3.1",
+            "JETTY_VERSION=9.2.9.v20150224",
+            "REV=107ea141f5c7581056c6eb53d2ccd222cdf0d58c"
+        ],
+        "ExposedPorts": {
+            "22/tcp": {},
+            "8080/tcp": {},
+            "8081/tcp": {}
+        },
+        "Hostname": "1d42a20b09ac",
+        "Image": "5366517d611967756a43c63a3223dbf645c5e9be66d594d86802dee143aad93a",
+        "Labels": null,
+        "MacAddress": "",
+        "Memory": 0,
+        "MemorySwap": 0,
+        "NetworkDisabled": false,
+        "OnBuild": [],
+        "OpenStdin": false,
+        "PortSpecs": null,
+        "StdinOnce": false,
+        "Tty": false,
+        "User": "",
+        "Volumes": null,
+        "WorkingDir": "/var/lib/jenkins/workflow-plugin-pipeline-demo"
+    },
+    "Created": "2015-04-01T14:15:30.700262841Z",
+    "DockerVersion": "1.5.0",
+    "Id": "5366517d611967756a43c63a3223dbf645c5e9be66d594d86802dee143aad93a",
+    "Os": "linux",
+    "Parent": "4300417211ebb75b48b06ed5640d641778f312072d24b37978682345cbb362b1",
+    "Size": 0,
+    "VirtualSize": 827600055
+  }
+]


### PR DESCRIPTION
This is a draft implementation of the on-demand creation of Docker fingerprints from docker-build-publich plugin. The current version has a limited usability due to the lack of the info in fingerprints. We assume that something like Docker Traceability Plugin will add more info later.

@reviewbybees