### PR TITLE
Added force option to docker tag commands. Useful for when doing tag …

### DIFF
--- a/src/main/java/com/cloudbees/dockerpublish/DockerBuilder.java
+++ b/src/main/java/com/cloudbees/dockerpublish/DockerBuilder.java
@@ -74,6 +74,7 @@ public class DockerBuilder extends Builder {
     private boolean createFingerprint = true;
     private boolean skipTagLatest;
     private String buildAdditionalArgs = "";
+    private boolean forceTag = true;
 
     @Deprecated
     public DockerBuilder(String repoName, String repoTag, boolean skipPush, boolean noCache, boolean forcePull, boolean skipBuild, boolean skipDecorate, boolean skipTagLatest, String dockerfilePath) {
@@ -216,6 +217,15 @@ public class DockerBuilder extends Builder {
         this.skipTagLatest = skipTagLatest;
     }
 
+    public boolean isForceTag() {
+        return forceTag;
+    }
+
+    @DataBoundSetter
+    public void setForceTag(boolean forceTag) {
+        this.forceTag = forceTag;
+    }
+
     /**
      * Fully qualified repository/image name with the registry url in front
      * @return ie. docker.acme.com/jdoe/busybox
@@ -322,7 +332,9 @@ public class DockerBuilder extends Builder {
             } else {
                 for (ImageTag imageTag : getImageTags()) {
                     result.add(
-                            "docker tag " + (imageTag.isLatest() ? "--force=true " : "") + getRepo() + " " + imageTag);
+                            "docker tag "
+                            + (imageTag.isLatest() || isForceTag() ? "--force=true " : "")
+                            + getRepo() + " " + imageTag);
                 }
             }
             return executeCmd(result);
@@ -345,7 +357,9 @@ public class DockerBuilder extends Builder {
             if (image != null) {
                 // we know the image name so apply the tags directly
                 while (lastResult.result && i.hasNext()) {
-                    lastResult = executeCmd("docker tag --force=true " + image + " " + i.next());
+                    lastResult = executeCmd("docker tag "
+                            + (isForceTag() ? "--force=true " : "")
+                            + image + " " + i.next());
                 }
                 processFingerprints(image);
             } else {

--- a/src/main/resources/com/cloudbees/dockerpublish/DockerBuilder/config.jelly
+++ b/src/main/resources/com/cloudbees/dockerpublish/DockerBuilder/config.jelly
@@ -56,6 +56,11 @@
       <f:textbox />
     </f:entry>
 
+    <f:entry title="Force Tag Replacement" field="forceTag"
+        description="Force tag replacement when tag already exists">
+        <f:checkbox default="true" />
+    </f:entry>
+
     <f:entry title="Additional Build Arguments" field="buildAdditionalArgs"
       description="Additional build arguments passed to docker build such as --build-arg https_proxy=&quot;http://some.proxy:port&quot;">
       <f:textbox />


### PR DESCRIPTION
During my workflow logic I am building a docker image then I am pushing and tagging the docker image with a given version (while skipping the latest tag) to a docker registry.

Once the docker image is available in the docker registry I want to run it in a CI Environment. Upon successful completion/pass of regression I want to update the docker registry with the latest tag on the docker image with the specific version.

Currently docker-build-publish-plugin fails for a tag only configuration because the original (version) tag already exists in the docker registry. To allow the behavior of overwriting tags we can add a new configuration to add --force=true option to the docker tag command being used.