### PR TITLE
Adding Docker push retry option

### DIFF
--- a/src/main/java/com/cloudbees/dockerpublish/DockerBuilder.java
+++ b/src/main/java/com/cloudbees/dockerpublish/DockerBuilder.java
@@ -65,14 +65,16 @@ public class DockerBuilder extends Builder {
     private boolean skipDecorate;
     @CheckForNull
     private String repoTag;
+    private String retryBuild;
     private boolean skipPush = true;
     private boolean createFingerprint = true;
     private boolean skipTagLatest;
 
     @Deprecated
-    public DockerBuilder(String repoName, String repoTag, boolean skipPush, boolean noCache, boolean forcePull, boolean skipBuild, boolean skipDecorate, boolean skipTagLatest, String dockerfilePath) {
+    public DockerBuilder(String repoName, String repoTag, String retryBuild, boolean skipPush, boolean noCache, boolean forcePull, boolean skipBuild, boolean skipDecorate, boolean skipTagLatest, String dockerfilePath) {
         this(repoName);
         this.repoTag = repoTag;
+        this.retryBuild = retryBuild;
         this.skipPush = skipPush;
         this.noCache = noCache;
         this.forcePull = forcePull;
@@ -163,6 +165,15 @@ public class DockerBuilder extends Builder {
     @DataBoundSetter
     public void setRepoTag(String repoTag) {
         this.repoTag = repoTag;
+    }
+
+    public String getRetryBuild() {
+        return retryBuild;
+    }
+
+    @DataBoundSetter
+    public void setRetryBuild(String retryBuild) {
+        this.retryBuild = retryBuild;
     }
 
     public boolean isSkipPush() {
@@ -334,9 +345,27 @@ public class DockerBuilder extends Builder {
         private boolean dockerPushCommand() throws InterruptedException, MacroEvaluationException, IOException {
         	List<String> result = new ArrayList<String>();
         	for (String tag: getNameAndTag()) {
+
         		result.add("docker push " + tag);
         	}
-        	return executeCmd(result);
+            boolean lastResult = executeCmd(result);
+            int retryNo=parse(getRetryBuild());
+        	while (!lastResult && retryNo>0)
+            {
+                logger.log(Level.INFO, "Retrying push command : {0} attempt", retryNo);
+                lastResult = executeCmd(result);
+                retryNo--;
+            }
+            return lastResult;
+        }
+
+        private  int parse(String p) {
+            if(p==null)     return 0;
+            try {
+                return Integer.parseInt(p);
+            } catch (NumberFormatException e) {
+                return -1;
+            }
         }
 
         private boolean executeCmd(List<String> cmds) throws IOException, InterruptedException {

--- a/src/main/resources/com/cloudbees/dockerpublish/DockerBuilder/config.jelly
+++ b/src/main/resources/com/cloudbees/dockerpublish/DockerBuilder/config.jelly
@@ -12,8 +12,15 @@
     <f:textbox />
   </f:entry>
 
+  <f:entry title="${%Retry for Docker Push}"
+        description="${%if not empty, Docker Push retry will run to this number of times}" field="retryBuild">
+        <f:number clazz="positive-number" min="1" step="1" />
+   </f:entry>
+
   <f:property field="server"/>
   <f:property field="registry"/>
+
+
 
   <f:advanced>
 

--- a/src/main/resources/com/cloudbees/dockerpublish/DockerBuilder/help-retryBuild.html
+++ b/src/main/resources/com/cloudbees/dockerpublish/DockerBuilder/help-retryBuild.html
@@ -1,0 +1,3 @@
+<div>
+	There are some intermittent issue (EOF, i/o timeout) while pushing image to docker registry.This option will retry the Docker push command
+</div>


### PR DESCRIPTION
We are hitting https://issues.jenkins-ci.org/browse/JENKINS-27229 issue even we are using latest version of docker-build-publish plugin.
This issue is intermittent and subsequent builds passed. We placed our shell script with retry option instead of using docker-build-publish plugin, we found build are running fine as subsequent attempt of failure goes successful.
So I added retry option in plugin, Please review and let me know if anythings need to be done here from my side.