### PR TITLE
Support for additional arguments during build

### DIFF
--- a/src/main/java/com/cloudbees/dockerpublish/DockerBuilder.java
+++ b/src/main/java/com/cloudbees/dockerpublish/DockerBuilder.java
@@ -73,6 +73,7 @@ public class DockerBuilder extends Builder {
     private boolean skipPush = true;
     private boolean createFingerprint = true;
     private boolean skipTagLatest;
+    private String buildAdditionalArgs = "";
 
     @Deprecated
     public DockerBuilder(String repoName, String repoTag, boolean skipPush, boolean noCache, boolean forcePull, boolean skipBuild, boolean skipDecorate, boolean skipTagLatest, String dockerfilePath) {
@@ -150,6 +151,15 @@ public class DockerBuilder extends Builder {
     @DataBoundSetter
     public void setDockerfilePath(String dockerfilePath) {
         this.dockerfilePath = Util.fixEmptyAndTrim(dockerfilePath);
+    }
+    
+    public String getBuildAdditionalArgs() {
+        return buildAdditionalArgs;
+    }
+
+    @DataBoundSetter
+    public void setBuildAdditionalArgs(String buildAdditionalArgs) {
+        this.buildAdditionalArgs = buildAdditionalArgs;
     }
 
     public boolean isSkipBuild() {
@@ -324,7 +334,7 @@ public class DockerBuilder extends Builder {
             Iterator<ImageTag> i = getImageTags().iterator();
             Result lastResult = new Result();
             if (i.hasNext()) {
-                lastResult = executeCmd("docker build -t " + i.next()
+                lastResult = executeCmd("docker build " + getBuildAdditionalArgs() + " -t " + i.next()
                     + ((isNoCache()) ? " --no-cache=true " : "") + " "
                     + ((isForcePull()) ? " --pull=true " : "") + " "
                     + (defined(getDockerfilePath()) ? " --file=" + getDockerfilePath() : "") + " "
@@ -341,7 +351,7 @@ public class DockerBuilder extends Builder {
             } else {
                 // we don't know the image name so rebuild the image for each tag
                 while (lastResult.result && i.hasNext()) {
-                    lastResult = executeCmd("docker build -t " + i.next()
+                    lastResult = executeCmd("docker build " + getBuildAdditionalArgs() +" -t " + i.next()
                         + ((isNoCache()) ? " --no-cache=true " : "") + " "
                         + ((isForcePull()) ? " --pull=true " : "") + " "
                         + (defined(getDockerfilePath()) ? " --file=" + getDockerfilePath() : "") + " "

--- a/src/main/resources/com/cloudbees/dockerpublish/DockerBuilder/config.jelly
+++ b/src/main/resources/com/cloudbees/dockerpublish/DockerBuilder/config.jelly
@@ -56,6 +56,11 @@
       <f:textbox />
     </f:entry>
 
+    <f:entry title="Additional Build Arguments" field="buildAdditionalArgs"
+      description="Additional build arguments passed to docker build such as --build-arg https_proxy=&quot;http://some.proxy:port&quot;">
+      <f:textbox />
+    </f:entry>
+
     <f:entry title="Dockerfile Path" field="dockerfilePath"
       description="Path to the Dockerfile for this build. File must be relative to build context. Can be used to specify a Dockerfile with a non-standard filename. Uses Docker client default if not specified.">
       <f:textbox />


### PR DESCRIPTION
Added support for passing additional arbitrary arguments to docker build command. For example --build-arg.  I use it for passing HTTP proxy information to docker daemon during build.