### PR TITLE
Allow space in workspace location

### DIFF
--- a/src/main/java/com/cloudbees/dockerpublish/DockerBuilder.java
+++ b/src/main/java/com/cloudbees/dockerpublish/DockerBuilder.java
@@ -355,7 +355,7 @@ public class DockerBuilder extends Builder {
                         + ((isNoCache()) ? " --no-cache=true " : "") + " "
                         + ((isForcePull()) ? " --pull=true " : "") + " "
                         + (defined(getDockerfilePath()) ? " --file=" + getDockerfilePath() : "") + " "
-                        + context);
+                        + "'" + context + "'");
                     processFingerprintsFromStdout(lastResult.stdout);
                 }
             }


### PR DESCRIPTION
This apply to the case where we don't know the image name