### PR TITLE
correct the link to the wiki page for plugins and remove buildhive link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Docker registry build plugin for Jenkins
 
-[![Build Status](https://buildhive.cloudbees.com/job/jenkinsci/job/docker-build-publish-plugin/badge/icon)](https://buildhive.cloudbees.com/job/jenkinsci/job/docker-build-publish-plugin/)
-
 If you want to build and push your Docker based project to the docker registry (including private repos), then you are in luck! This is an early version - tweet @michaelneale if you have questions.
 
 Features:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Docker registry build plugin for Jenkins
 
+[![Build Status](https://jenkins.ci.cloudbees.com/job/plugins/job/docker-build-publish-plugin/badge/icon)](https://jenkins.ci.cloudbees.com/job/plugins/job/docker-build-publish-plugin/)
+
 If you want to build and push your Docker based project to the docker registry (including private repos), then you are in luck! This is an early version - tweet @michaelneale if you have questions.
 
 Features:

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <description>
     This plugin provides the ability to build projects with a Dockerfile, and publish the resultant tagged image (repo) to a Docker registry.
   </description>
-  <url>https://github.com/jenkinsci/docker-build-publish-plugin/blob/master/README.md</url>
+  <url>https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Docker+Build+and+Publish+plugin</url>
   <licenses>
     <license>
       <name>The MIT license</name>


### PR DESCRIPTION
@batmat @carlossg  how does this look? 

(regarding https://github.com/jenkinsci/docker-build-publish-plugin/commit/55f7fbf8094d5e65fbf78b1a52022159eb1cc3c5#commitcomment-15190609)