### PR TITLE
squid:S1213 - The members of an interface declaration or class should…

### DIFF
--- a/src/main/java/com/cloudbees/dockerpublish/DockerBuilder.java
+++ b/src/main/java/com/cloudbees/dockerpublish/DockerBuilder.java
@@ -524,6 +524,22 @@ public class DockerBuilder extends Builder {
      */
     @Extension
     public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
+        @SuppressWarnings("unused")
+        private transient String userName;
+        @SuppressWarnings("unused")
+        private transient String password;
+        @SuppressWarnings("unused")
+        private transient String email;
+        @SuppressWarnings("unused")
+        private transient String registryUrl;
+
+        /**
+         * In order to load the persisted global configuration, you have to 
+         * call load() in the constructor.
+         */
+        public DescriptorImpl() {
+            load();
+        }
 
         // Using docker-commons now, methods left for backwards compatibility
 
@@ -544,23 +560,6 @@ public class DockerBuilder extends Builder {
         @SuppressWarnings("unused")
         @Restricted(NoExternalUse.class)
         public String getRegistryUrl() { return registryUrl; }
-
-        @SuppressWarnings("unused")
-        private transient String userName;
-        @SuppressWarnings("unused")
-        private transient String password;
-        @SuppressWarnings("unused")
-        private transient String email;
-        @SuppressWarnings("unused")
-        private transient String registryUrl;
-
-        /**
-         * In order to load the persisted global configuration, you have to 
-         * call load() in the constructor.
-         */
-        public DescriptorImpl() {
-            load();
-        }
 
         /**
          * Performs on-the-fly validation of the form field 'repoName'.


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1213

Please let me know if you have any questions.

M-Ezzat