### PR TITLE
Use Docker Commons to find docker tool

### DIFF
--- a/src/main/java/com/cloudbees/dockerpublish/DockerBuilder.java
+++ b/src/main/java/com/cloudbees/dockerpublish/DockerBuilder.java
@@ -506,7 +506,7 @@ public class DockerBuilder extends Builder {
             }
             
             // Retrieve full image ID using another call
-            final Result response = executeCmd("docker inspect " + image, false, true);
+            final Result response = executeCmd("inspect " + image, false, true);
             if (!response.result) {
                 return; // Bad result, cannot do anything
             }

--- a/src/main/resources/com/cloudbees/dockerpublish/DockerBuilder/config.jelly
+++ b/src/main/resources/com/cloudbees/dockerpublish/DockerBuilder/config.jelly
@@ -1,4 +1,4 @@
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:dc="/lib/docker/commons">
   <!--
     This jelly script is used for per-project configuration.
 
@@ -70,6 +70,8 @@
       description="Path to the Dockerfile for this build. File must be relative to build context. Can be used to specify a Dockerfile with a non-standard filename. Uses Docker client default if not specified.">
       <f:textbox />
     </f:entry>
+
+    <dc:selectDockerTool field="dockerToolName"/>
 
   </f:advanced>
 


### PR DESCRIPTION
Having the requirement to have docker in the path is problematic for those of us who runs Jenkins in Docker from the official image.

So this introduces settings for allowing Docker Commons to install the command used.