### PR TITLE
Fix for JENKINS-35000 - incorrect file backslash when slave is linux

### DIFF
--- a/src/main/java/com/cloudbees/dockerpublish/DockerBuilder.java
+++ b/src/main/java/com/cloudbees/dockerpublish/DockerBuilder.java
@@ -341,8 +341,16 @@ public class DockerBuilder extends Builder {
         }
 
         private boolean buildAndTag() throws MacroEvaluationException, IOException, InterruptedException {
-            FilePath context = defined(expandAll(getBuildContext())) ? new FilePath(new File(expandAll(getBuildContext())))
-                    : build.getWorkspace();
+            FilePath context;
+            if (defined(expandAll(getBuildContext()))) {
+                if (build.getBuiltOn() != null) {
+                    context = build.getBuiltOn().createPath(expandAll(getBuildContext()));
+                } else {
+                    context = new FilePath(new File(expandAll(getBuildContext())));
+                }
+            } else {
+                context = build.getWorkspace();
+            }
             Iterator<ImageTag> i = getImageTags().iterator();
             Result lastResult = new Result();
             if (i.hasNext()) {

--- a/src/main/java/com/cloudbees/dockerpublish/DockerBuilder.java
+++ b/src/main/java/com/cloudbees/dockerpublish/DockerBuilder.java
@@ -8,6 +8,7 @@ import hudson.FilePath;
 import hudson.Launcher;
 import hudson.Util;
 import hudson.model.BuildListener;
+import hudson.model.Node;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.tasks.BuildStepDescriptor;
@@ -343,8 +344,10 @@ public class DockerBuilder extends Builder {
         private boolean buildAndTag() throws MacroEvaluationException, IOException, InterruptedException {
             FilePath context;
             if (defined(expandAll(getBuildContext()))) {
-                if (build.getBuiltOn() != null) {
-                    context = build.getBuiltOn().createPath(expandAll(getBuildContext()));
+            	Node builtOn = build.getBuiltOn();
+            	
+                if (builtOn != null) {
+                    context = builtOn.createPath(expandAll(getBuildContext()));
                 } else {
                     context = new FilePath(new File(expandAll(getBuildContext())));
                 }


### PR DESCRIPTION
Fix for JENKINS-35000 - Docker build on linux slave fails due to '\' backslash

https://issues.jenkins-ci.org/browse/JENKINS-35000?jql=project%20%3D%20JENKINS%20AND%20status%20in%20(Open%2C%20%22In%20Progress%22%2C%20Reopened)%20AND%20component%20%3D%20%27docker-build-publish-plugin%27

