### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/src/main/java/com/cloudbees/dockerpublish/DockerCLIHelper.java
+++ b/src/main/java/com/cloudbees/dockerpublish/DockerCLIHelper.java
@@ -43,8 +43,12 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  * @since TODO
  */
 @Restricted(NoExternalUse.class)
-public class DockerCLIHelper {
-    
+public final class DockerCLIHelper {
+
+    private DockerCLIHelper() throws InstantiationException {
+        throw new InstantiationException("This helper class is not created for instantiation");
+    }
+
     /**
      * Parses console output from a {@link ByteArrayOutputStream}.
      * @param output Output stream


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.

M-Ezzat