### PR TITLE
[JENKINS-35707] - Upgrade to parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,13 +5,17 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.554.2</version><!-- which version of Jenkins is this plugin built against? -->
+    <version>2.9</version><!-- which version of Jenkins is this plugin built against? -->
   </parent>
 
   <artifactId>docker-build-publish</artifactId>
   <version>1.2.3-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
+  <properties>
+    <jenkins.version>1.554.2</jenkins.version>
+    <java.level>6</java.level>
+  </properties>
 
   <name>CloudBees Docker Build and Publish plugin</name>
   <description>
@@ -36,13 +40,13 @@
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
   </repositories>
   <pluginRepositories>
     <pluginRepository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
 
@@ -57,29 +61,6 @@
       <artifactId>token-macro</artifactId>
       <version>1.10</version>
     </dependency>
-    <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>annotations</artifactId>
-      <version>3.0.0</version>
-    </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-release-plugin</artifactId>
-        <version>2.5.2</version>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <version>3.0.2</version>
-        <configuration>
-          <xmlOutput>true</xmlOutput>
-          <failOnError>false</failOnError>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 
 </project>

--- a/src/main/resources/com/cloudbees/dockerpublish/DockerBuilder/config.jelly
+++ b/src/main/resources/com/cloudbees/dockerpublish/DockerBuilder/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <!--
     This jelly script is used for per-project configuration.

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,6 +1,7 @@
 <!--
   This view is used to render the installed plugins page.
 -->
+<?jelly escape-by-default='true'?>
 <div>
   This plugin enables building Dockerfile based projects,
   as well as publishing of the built images/repos to the docker registry.


### PR DESCRIPTION
Kept the version at 1.554.2 since at one point that was an LTS line. Also ran suite with jenkins.version=1.580.1 and everything passes just in case that's the route we want to take with this.  Remove dependencies that will now be found in the parent.  All tests had been upgraded to JenkinsRule, so they are pretty well maintained.  Tested without errors against base and 2.7.

@reviewbybees 