### PR TITLE
compatibility upgrade for jenkins 2+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.554.2</version><!-- which version of Jenkins is this plugin built against? -->
+    <version>2.9</version><!-- which version of Jenkins is this plugin built against? -->
   </parent>
 
   <artifactId>docker-build-publish</artifactId>

--- a/src/main/resources/com/cloudbees/dockerpublish/DockerBuilder/config.jelly
+++ b/src/main/resources/com/cloudbees/dockerpublish/DockerBuilder/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <!--
     This jelly script is used for per-project configuration.

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,6 +1,7 @@
 <!--
   This view is used to render the installed plugins page.
 -->
+<?jelly escape-by-default='true'?>
 <div>
   This plugin enables building Dockerfile based projects,
   as well as publishing of the built images/repos to the docker registry.

--- a/src/test/java/com/cloudbees/dockerpublish/DockerBuilderTest.java
+++ b/src/test/java/com/cloudbees/dockerpublish/DockerBuilderTest.java
@@ -113,9 +113,7 @@ public class DockerBuilderTest {
 
         DockerBuilder after = project.getBuildersList().get(DockerBuilder.class);
 
-        jenkins.assertEqualBeans(before, after, "repoName,buildContext,createFingerprint," +
-            "dockerfilePath,forcePull,noCache,registry,repoTag,server,skipBuild," +
-            "skipDecorate,skipPush,skipTagLatest");
+        jenkins.assertEqualDataBoundBeans(before, after);
     }
 
     @Test


### PR DESCRIPTION
* upgrade to a more recent parent pom for testing against jenkins 2.0+
* satiate some new tests re:xss vulnerabilities, more on that here: https://wiki.jenkins-ci.org/display/JENKINS/Jelly+and+XSS+prevention
* use the magic of assertEqualDataBoundBeans instead of assertEqualBeans

Tested end-to-end on jenkins 1.651.3 and 2.9