### PR TITLE
Fix prefixing echo with docker

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>docker-build-publish</artifactId>
-  <version>1.3.2-SNAPSHOT</version>
+  <version>1.3.2a-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <properties>

--- a/src/main/java/com/cloudbees/dockerpublish/DockerBuilder.java
+++ b/src/main/java/com/cloudbees/dockerpublish/DockerBuilder.java
@@ -475,8 +475,12 @@ public class DockerBuilder extends Builder {
 	            }
             }
             
-            cmd = dockerCmd + " " +cmd;
-            
+	    /* If command is not a docker command don't prefix with docker */
+
+            if (!cmd.startsWith("echo")) {
+		cmd = dockerCmd + " " +cmd;
+            }
+
             logger.log(Level.FINER, "Executing: {0}", cmd);
 
             try {


### PR DESCRIPTION
This fix corrects the problem that was introduced when executeCmd was changed to prefix all commands with "docker". There is one case where the output is not a docker command, but an "echo Nothing to build or tag." Because of the default prefixing that was causing builds to fail.