### PR TITLE
Use expandAll() around dockerfilePath

### DIFF
--- a/src/main/java/com/cloudbees/dockerpublish/DockerBuilder.java
+++ b/src/main/java/com/cloudbees/dockerpublish/DockerBuilder.java
@@ -376,7 +376,7 @@ public class DockerBuilder extends Builder {
                 lastResult = executeCmd("build " + expandAll(getBuildAdditionalArgs()) + " -t " + i.next()
                     + ((isNoCache()) ? " --no-cache=true " : "") + " "
                     + ((isForcePull()) ? " --pull=true " : "") + " "
-                    + (defined(getDockerfilePath()) ? " --file=" + getDockerfilePath() : "") + " "
+                    + (defined(getDockerfilePath()) ? " --file=" + expandAll(getDockerfilePath()) : "") + " "
                     + "'" + context + "'");
             }
             // get the image to save rebuilding it to apply the other tags


### PR DESCRIPTION
Hello!

I've noticed, that "Dockerfile Path" field has no macro handling, so I've added expandAll() around Dockerfile path. 

Tested on my Jenkins instance, works OK.