### PR TITLE
Expandable variables in DockerRegistry field

### DIFF
--- a/src/main/java/com/cloudbees/dockerpublish/DockerBuilder.java
+++ b/src/main/java/com/cloudbees/dockerpublish/DockerBuilder.java
@@ -376,7 +376,7 @@ public class DockerBuilder extends Builder {
                 lastResult = executeCmd("build " + expandAll(getBuildAdditionalArgs()) + " -t " + i.next()
                     + ((isNoCache()) ? " --no-cache=true " : "") + " "
                     + ((isForcePull()) ? " --pull=true " : "") + " "
-                    + (defined(getDockerfilePath()) ? " --file=" + getDockerfilePath() : "") + " "
+                    + (defined(getDockerfilePath()) ? " --file=" + expandAll(getDockerfilePath()) : "") + " "
                     + "'" + context + "'");
             }
             // get the image to save rebuilding it to apply the other tags


### PR DESCRIPTION
Hello!

I've noticed, that expandable variables do not work as expected if I use them in "Docker registry URL" field. 
Everything works as expected, except for .dockercfg file created by Docker Commons Plugin.
If I use a variable in that field, file looks like this:

```
{ "https://${REGISTRY}":   {
    "auth": "<some base64 symbols>",
    "email": "<my_email@somewhere"
}}
```

As long as Docker Commons Plugin authors do not want to add yet another dependency, even this common, as TokenMacro Plugin, I've made a hack that allows me to use variables and expand them.

I tested it on my system and it seems to work OK.

I also had to add MacroEvaluationException to several methods' "throws", as long as executeCmd() now throws it.

I understand that this looks more like dirty hack, than a good code, but this is the only way I could produce to solve the problem.
