### PR TITLE
force rebuild typo

### DIFF
--- a/src/main/resources/com/cloudbees/dockerpublish/DockerBuilder/config.jelly
+++ b/src/main/resources/com/cloudbees/dockerpublish/DockerBuilder/config.jelly
@@ -24,7 +24,7 @@
     </f:entry>
 
     <f:entry title="No Cache" field="noCache"
-        description="Force rebuild - do not user docker cache (may be slower)">
+        description="Force rebuild - do not use docker cache (may be slower)">
         <f:checkbox />
     </f:entry>
 
@@ -37,7 +37,7 @@
         description="Do not build the image">
         <f:checkbox />
     </f:entry>
-    
+
     <f:entry title="${%Create fingerprints}" field="createFingerprint">
         <f:checkbox default="true"/>
     </f:entry>


### PR DESCRIPTION
Configuration panel in Jenkins contains typo in Force Rebuild checkbox label:
<img width="578" alt="docker-build-publish" src="https://user-images.githubusercontent.com/1908699/69140552-019a2080-0ac3-11ea-97b7-027e94a7afd7.png">
